### PR TITLE
UI feedback when saving the Sourcegraph URL

### DIFF
--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -17,6 +17,7 @@
         <p>
             Connect Bitbucket to your Sourcegraph instance to get code intelligence on code views and pull requests.
         </p>
+        <div class="aui-message hidden" id="message"></div>
         <form id="admin" class="aui">
             <div class="field-group">
                 <label for="url">Sourcegraph URL:</label>

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -7,12 +7,22 @@ AJS.toInit(async () => {
     const errorClasses = ['aui-message-error', 'error']
     const successClasses = ['aui-message-success', 'success']
 
+    /**
+     * Displays an error or success message in the `messageContainer` element.
+     *
+     * @param {string} type The type of the message as a string: `'error' | 'success'`.
+     * @param {string} message The message to display.
+     */
+    const showMessage = (type, message) => {
+        messageContainer.add(...(type === 'error' ? errorClasses : successClasses))
+        messageContainer.textContent = message
+        messageContainer.classList.remove('hidden')
+    }
+
     // Fetch Sourcegraph URL value on page load.
     const response = await fetch(restURL)
     if (!response.ok) {
-        messageContainer.classList.add(...errorClasses)
-        messageContainer.textContent = `Error fetching the Sourcegraph URL: ${response.status} ${response.statusText}`
-        messageContainer.classList.remove('hidden')
+        showMessage('error', `Error fetching the Sourcegraph URL: ${response.status} ${response.statusText}`)
         return
     }
 
@@ -39,12 +49,9 @@ AJS.toInit(async () => {
 
         // Display a success/error message
         if (!response.ok) {
-            messageContainer.classList.add(...errorClasses)
-            messageContainer.textContent = `Error saving the Sourcegraph URL: received status code ${response.status}.`
+            showMessage('error', `Error saving the Sourcegraph URL: received status code ${response.status}.`)
         } else {
-            messageContainer.classList.add(...successClasses)
-            messageContainer.textContent = `Sourcegraph URL successfully saved.`
+            showMessage('success', `Sourcegraph URL successfully saved.`)
         }
-        messageContainer.classList.remove('hidden')
     })
 })

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -49,7 +49,7 @@ AJS.toInit(async () => {
 
         // Display a success/error message
         if (!response.ok) {
-            showMessage('error', `Error saving the Sourcegraph URL: received status code ${response.status}.`)
+            showMessage('error', `Error saving the Sourcegraph URL: ${response.status} ${response.statusText}.`)
         } else {
             showMessage('success', `Sourcegraph URL successfully saved.`)
         }

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -1,26 +1,50 @@
-AJS.toInit(() => {
-  const url = AJS.contextPath() + '/rest/sourcegraph-admin/1.0/'
+AJS.toInit(async () => {
+    const restURL = AJS.contextPath() + '/rest/sourcegraph-admin/1.0/'
+    const adminForm = document.getElementById('admin')
+    const submitBtn = document.getElementById('submit')
+    const messageContainer = document.getElementById('message')
+    const urlInput = document.getElementById('url')
+    const errorClasses = ['aui-message-error', 'error']
+    const successClasses = ['aui-message-success', 'success']
 
-  // Fetch Sourcegraph URL value on page load.
-  AJS.$.ajax({
-    url,
-    dataType: 'json'
-  }).done(({ url }) => {
-    document.getElementById('url').value = url || ''
-  })
+    // Fetch Sourcegraph URL value on page load.
+    const response = await fetch(restURL)
+    if (!response.ok) {
+        messageContainer.classList.add(...errorClasses)
+        messageContainer.textContent = `Error fetching the Sourcegraph URL: received status code ${response.status}.`
+        messageContainer.classList.remove('hidden')
+        return
+    }
 
-  // Update Sourcegraph URL when form is submitted.
-  AJS.$('#admin').submit(e => {
-    e.preventDefault()
-    const data = JSON.stringify({
-      url: document.getElementById('url').value
+    const { url } = await response.json()
+    urlInput.value = url || ''
+
+    // Update Sourcegraph URL when the form is submitted.
+    adminForm.addEventListener('submit', async e => {
+        e.preventDefault()
+        submitBtn.classList.add('disabled')
+        messageContainer.classList.remove(...errorClasses, ...successClasses)
+        messageContainer.classList.add('hidden')
+
+        const response = await fetch(restURL, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                url: document.getElementById('url').value,
+            }),
+        })
+        submitBtn.classList.remove('disabled')
+
+        // Display a success/error message
+        if (!response.ok) {
+            messageContainer.classList.add(...errorClasses)
+            messageContainer.textContent = `Error saving the Sourcegraph URL: received status code ${response.status}.`
+        } else {
+            messageContainer.classList.add(...successClasses)
+            messageContainer.textContent = `Sourcegraph URL successfully saved.`
+        }
+        messageContainer.classList.remove('hidden')
     })
-    AJS.$.ajax({
-      url: AJS.contextPath() + "/rest/sourcegraph-admin/1.0/",
-      type: "PUT",
-      contentType: "application/json",
-      data,
-      processData: false
-    });
-  })
 })

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -11,7 +11,7 @@ AJS.toInit(async () => {
     const response = await fetch(restURL)
     if (!response.ok) {
         messageContainer.classList.add(...errorClasses)
-        messageContainer.textContent = `Error fetching the Sourcegraph URL: received status code ${response.status}.`
+        messageContainer.textContent = `Error fetching the Sourcegraph URL: ${response.status} ${response.statusText}`
         messageContainer.classList.remove('hidden')
         return
     }

--- a/src/main/resources/js/sourcegraph-bitbucket.js
+++ b/src/main/resources/js/sourcegraph-bitbucket.js
@@ -1,23 +1,25 @@
-AJS.toInit(() => {
+AJS.toInit(async () => {
     // Fetch Sourcegraph URL on page load
-    AJS.$.ajax({
-        url: AJS.contextPath() + '/rest/sourcegraph-admin/1.0/',
-        dataType: 'json'
-    }).done(({ url }) => {
-        if (!url) {
-            console.log(`No Sourcegraph URL is set. To set a Sourcegraph URL, log in as a site admin and navigate to ${AJS.contextPath()}/plugins/servlet/sourcegraph.`)
-            return
-        }
-        // If a Sourcegraph URL is set,
-        // inject a <script> tag to fetch the main JS bundle
-        // from the Sourcegraph instance
-        window.SOURCEGRAPH_URL = url
-        window.localStorage.SOURCEGRAPH_URL = url
-        window.SOURCEGRAPH_INTEGRATION = 'bitbucket-integration'
-        var script = document.createElement('script')
-        script.type = 'text/javascript'
-        script.defer = true
-        script.src = url + '/.assets/extension/scripts/integration.bundle.js'
-        document.getElementsByTagName('head')[0].appendChild(script)
-    })
+    const response = await fetch(AJS.contextPath() + '/rest/sourcegraph-admin/1.0/')
+    if (!response.ok) {
+        console.error(`Error fetching Sourcegraph URL: ${response.status}`)
+    }
+    const { url } = await response.json()
+    if (!url) {
+        console.log(
+            `No Sourcegraph URL is set. To set a Sourcegraph URL, log in as a site admin and navigate to ${AJS.contextPath()}/plugins/servlet/sourcegraph.`
+        )
+        return
+    }
+    // If a Sourcegraph URL is set,
+    // inject a <script> tag to fetch the main JS bundle
+    // from the Sourcegraph instance
+    window.SOURCEGRAPH_URL = url
+    window.localStorage.SOURCEGRAPH_URL = url
+    window.SOURCEGRAPH_INTEGRATION = 'bitbucket-integration'
+    var script = document.createElement('script')
+    script.type = 'text/javascript'
+    script.defer = true
+    script.src = url + '/.assets/extension/scripts/integration.bundle.js'
+    document.getElementsByTagName('head')[0].appendChild(script)
 })


### PR DESCRIPTION
Having no UI feedback when saving the Sourcegraph URL was awkward. This adds a simple success/error notification when saving the Sourcegraph URL from the admin settings form, modeled after what other Bitbucket Server plugins / settings pages do.

![image](https://user-images.githubusercontent.com/1741180/60727079-56d2fc80-9f3d-11e9-82b2-4b6b7415e9c8.png)

![image](https://user-images.githubusercontent.com/1741180/60727087-59cded00-9f3d-11e9-881e-d3c803effe84.png)
