### PR TITLE
Make cancel link relative to the Bitbucket baseUrl

### DIFF
--- a/src/main/java/com/sourcegraph/admin/AdminServlet.java
+++ b/src/main/java/com/sourcegraph/admin/AdminServlet.java
@@ -1,21 +1,23 @@
 package com.sourcegraph.admin;
 
+import com.atlassian.bitbucket.server.ApplicationPropertiesService;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.templaterenderer.TemplateRenderer;
 
-
-import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
-import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.net.URI;
-import com.atlassian.sal.api.auth.LoginUriProvider;
-import com.atlassian.sal.api.user.UserManager;
 
 
 
@@ -26,13 +28,15 @@ public class AdminServlet extends HttpServlet
     private final TemplateRenderer templateRenderer;
     private final UserManager userManager;
     private final LoginUriProvider loginUriProvider;
+    private final ApplicationPropertiesService propertiesService;
 
   @Autowired
-  public AdminServlet(@ComponentImport TemplateRenderer templateRenderer, @ComponentImport UserManager userManager, @ComponentImport LoginUriProvider loginUriProvider)
+  public AdminServlet(@ComponentImport TemplateRenderer templateRenderer, @ComponentImport UserManager userManager, @ComponentImport LoginUriProvider loginUriProvider, @ComponentImport ApplicationPropertiesService propertiesService)
   {
       this.templateRenderer = templateRenderer;
       this.userManager = userManager;
       this.loginUriProvider = loginUriProvider;
+      this.propertiesService = propertiesService;
   }
 
   @Override
@@ -44,9 +48,12 @@ public class AdminServlet extends HttpServlet
           redirectToLogin(request, response);
           return;
         }
-
+        Map<String, Object> context = new HashMap<>();
+        URI baseUrl = propertiesService.getBaseUrl();
+        String baseUrlString = baseUrl.toString();
+        context.put("baseUrl", baseUrlString);
         response.setContentType("text/html;charset=utf-8");
-        templateRenderer.render("admin.vm", response.getWriter());
+        templateRenderer.render("admin.vm", context, response.getWriter());
   }
 
   private void redirectToLogin(HttpServletRequest request, HttpServletResponse response) throws IOException

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -29,7 +29,7 @@
             <div class="buttons-container">
                 <div class="buttons">
                     <input class="aui-button aui-button-primary" type="submit" id="submit" name="submit" value="Save" accesskey="s">
-                    <a id="cancel" class="aui-button aui-button-link cancel" name="cancel" accesskey="c" href="/admin" autocomplete="off" tabindex="0">Cancel</a></div>
+                    <a id="cancel" class="aui-button aui-button-link cancel" name="cancel" accesskey="c" href="$baseUrl/admin" autocomplete="off" tabindex="0">Cancel</a></div>
             </div>
         </form>
     </body>


### PR DESCRIPTION
Previously, broken links could happen if the instance was hosted at `some.domain.org/bitbucket`.