### PR TITLE
Make URL input disabled on page load

### DIFF
--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -21,7 +21,7 @@
         <form id="admin" class="aui">
             <div class="field-group">
                 <label for="url">Sourcegraph URL:</label>
-                <input class="text long-field" type="text" id="url" name="url" autofocus>
+                <input class="text long-field" type="text" id="url" name="url" disabled>
                 <div class="description">
                     This is the URL of your Sourcegraph instance. Example: https://sourcegraph.internal.org
                 </div>

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -20,14 +20,18 @@ AJS.toInit(async () => {
     }
 
     // Fetch Sourcegraph URL value on page load.
-    const response = await fetch(restURL)
-    if (!response.ok) {
-        showMessage('error', `Error fetching the Sourcegraph URL: ${response.status} ${response.statusText}`)
-        return
+    try {
+      const response = await fetch(restURL)
+      if (!response.ok) {
+          showMessage('error', `Error fetching the Sourcegraph URL: ${response.status} ${response.statusText}`)
+      } else {
+        const { url } = await response.json()
+        urlInput.value = url || ''
+      }
+    } finally {
+      urlInput.removeAttribute('disabled')
+      urlInput.focus()
     }
-
-    const { url } = await response.json()
-    urlInput.value = url || ''
 
     // Update Sourcegraph URL when the form is submitted.
     adminForm.addEventListener('submit', async e => {

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -29,7 +29,7 @@ AJS.toInit(async () => {
         urlInput.value = url || ''
       }
     } finally {
-      urlInput.removeAttribute('disabled')
+      urlInput.disabled = false
       urlInput.focus()
     }
 

--- a/src/main/resources/js/sourcegraph-bitbucket-admin.js
+++ b/src/main/resources/js/sourcegraph-bitbucket-admin.js
@@ -28,6 +28,8 @@ AJS.toInit(async () => {
         const { url } = await response.json()
         urlInput.value = url || ''
       }
+    } catch (err) {
+        showMessage('error', `Error fetching the Sourcegraph URL: ${err.message || err}`)
     } finally {
       urlInput.disabled = false
       urlInput.focus()


### PR DESCRIPTION
On the admin form, make the sourcegraph URL input disabled on page load, until the Sourcegraph URL has been fetched.