### PR TITLE
webhook: combine scope and identifier to selector

### DIFF
--- a/src/main/java/com/sourcegraph/webhook/registry/Webhook.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/Webhook.java
@@ -10,9 +10,7 @@ public class Webhook {
     @Expose
     public String name;
     @Expose
-    public String scope;
-    @Expose
-    public String identifier;
+    public String selector;
     @Expose
     public Set<String> events;
     @Expose
@@ -20,11 +18,10 @@ public class Webhook {
     @Expose(serialize = false)
     public String secret;
 
-    public Webhook(int id, String name, String scope, String identifier, Set<String> events, String endpoint, String secret) {
+    public Webhook(int id, String name, String selector, Set<String> events, String endpoint, String secret) {
         this.id = id;
         this.name = name;
-        this.scope = scope;
-        this.identifier = identifier;
+        this.selector = selector;
         this.events = events;
         this.endpoint = endpoint;
         this.secret = secret;

--- a/src/main/java/com/sourcegraph/webhook/registry/Webhook.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/Webhook.java
@@ -10,7 +10,7 @@ public class Webhook {
     @Expose
     public String name;
     @Expose
-    public String selector;
+    public String scope;
     @Expose
     public Set<String> events;
     @Expose
@@ -18,10 +18,10 @@ public class Webhook {
     @Expose(serialize = false)
     public String secret;
 
-    public Webhook(int id, String name, String selector, Set<String> events, String endpoint, String secret) {
+    public Webhook(int id, String name, String scope, Set<String> events, String endpoint, String secret) {
         this.id = id;
         this.name = name;
-        this.selector = selector;
+        this.scope = scope;
         this.events = events;
         this.endpoint = endpoint;
         this.secret = secret;

--- a/src/main/java/com/sourcegraph/webhook/registry/WebhookEntity.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/WebhookEntity.java
@@ -6,7 +6,7 @@ import net.java.ao.OneToMany;
 public interface WebhookEntity extends Entity {
     String getName();
 
-    String getSelector();
+    String getScope();
 
     @OneToMany
     EventEntity[] getEvents();

--- a/src/main/java/com/sourcegraph/webhook/registry/WebhookEntity.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/WebhookEntity.java
@@ -6,9 +6,7 @@ import net.java.ao.OneToMany;
 public interface WebhookEntity extends Entity {
     String getName();
 
-    String getScope();
-
-    int getIdentifier();
+    String getSelector();
 
     @OneToMany
     EventEntity[] getEvents();

--- a/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
@@ -120,6 +120,10 @@ public class WebhookRegistry {
     }
 
     private static String resolveSelectorID(String selector) throws WebhookException {
+        if (selector == null) {
+            throw new WebhookException(WebhookException.Status.UNPROCESSABLE_ENTITY, "Missing selector");
+        }
+
         if (selector.equals("global")) {
             return selector;
         }

--- a/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
@@ -40,14 +40,15 @@ public class WebhookRegistry {
     public static List<Webhook> getWebhooks(List<String> keys, Repository repository) {
         String params = Joiner.on(", ").join(Collections.nCopies(keys.size(), "?"));
         Iterable<Object> args = Iterables.concat(keys, Arrays.asList(
-                repository.getId(),
-                repository.getProject().getId()
+                repository.getProject().getId(),
+                repository.getId()
         ));
 
         String where = "event.EVENT in (" + params + ") "
-                + "AND (webhook.SCOPE = \'global\' "
-                + "OR (webhook.SCOPE = \'project\' AND webhook.IDENTIFIER = ?) "
-                + "OR (webhook.SCOPE = \'repository\' AND webhook.IDENTIFIER = ?))";
+                + "AND (webhook.SELECTOR = \'global\' "
+                + "OR (webhook.SELECTOR = CONCAT(\'project\', ':',  ?)) "
+                + "OR (webhook.SELECTOR = CONCAT(\'repository\', ':', ?)))";
+        System.out.println(where);
 
         Query query = Query.select()
                 .alias(WebhookEntity.class, "webhook")


### PR DESCRIPTION
This PR combines the webhook fields `scope` and `identifier` into a single field `scope`.
```
scope = <selector>:<identifier>
```

Ex:
```
curl http://localhost:7990/bitbucket/rest/sourcegraph-admin/1.0/webhook -X POST -u admin:admin -H 'Content-Type: application/json' \
    -d '{"name":"cool", "selector":"project:Project 1", "events":["pr"], "endpoint":"", "secret":""}'
```

This is a part of sourcegraph/sourcegraph#6091.