### PR TITLE
Switch to using scheduler instead of Thread.sleep

### DIFF
--- a/src/main/java/com/sourcegraph/webhook/Dispatcher.java
+++ b/src/main/java/com/sourcegraph/webhook/Dispatcher.java
@@ -87,7 +87,7 @@ public class Dispatcher implements Runnable {
         attempt++;
 
         if (attempt == MAX_ATTEMPTS) {
-            log.warn("Exceeded maximum (" + MAX_ATTEMPTS + ") attempts trying to dispatch webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "]");
+            log.warn("Exceeded maximum (" + MAX_ATTEMPTS + ") attempts to dispatch webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "]");
             return;
         }
 

--- a/src/main/java/com/sourcegraph/webhook/Dispatcher.java
+++ b/src/main/java/com/sourcegraph/webhook/Dispatcher.java
@@ -78,7 +78,7 @@ public class Dispatcher implements Runnable {
         try {
             Response response = (Response) request.executeAndReturn((resp) -> resp);
             if (response.isSuccessful()) {
-                log.debug("Dispatching webhook (" + serializer.getName() + ") data to URL: [" + hook.endpoint + "] succeeded.");
+                log.debug("Successfully dispatched webhook (" + serializer.getName() + ") data to URL: [" + hook.endpoint + "].");
                 return;
             }
         } catch (ResponseException e) {

--- a/src/main/java/com/sourcegraph/webhook/Dispatcher.java
+++ b/src/main/java/com/sourcegraph/webhook/Dispatcher.java
@@ -82,12 +82,12 @@ public class Dispatcher implements Runnable {
                 return;
             }
         } catch (ResponseException e) {
-            log.debug("Dispatching webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "] failed with error:\n" + e);
+            log.debug("Failed to dispatch webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "]:\n" + e);
         }
         attempt++;
 
         if (attempt == MAX_ATTEMPTS) {
-            log.warn("Dispatching webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "] failed after " + attempt + " attempts..");
+            log.warn("Exceeded maximum (" + MAX_ATTEMPTS + ") attempts trying to dispatch webhook data (" + serializer.getName() + ") to URL: [" + hook.endpoint + "]");
             return;
         }
 


### PR DESCRIPTION
This is the idiomatic way in java to run delayed code opposed to using `Thread.sleep`. This is for retries in the case that an event payload request fails.

This is a part of sourcegraph/sourcegraph#6091.