### PR TITLE
Add fast permissions endpoint with roaring bitmaps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.sourcegraph.plugins</groupId>
@@ -8,7 +9,9 @@
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>
-    <description>The Sourcegraph plugin for Bitbucket Server communicates with your Sourcegraph instance to add code intelligence to your Bitbucket Server code views and pull requests.</description>
+    <description>The Sourcegraph plugin for Bitbucket Server communicates with your Sourcegraph instance to add code
+        intelligence to your Bitbucket Server code views and pull requests.
+    </description>
 
     <organization>
         <name>Sourcegraph</name>
@@ -46,6 +49,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>0.8.11</version>
+        </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.8.11</version>
+            <version>0.6.66</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/src/main/java/com/sourcegraph/admin/AdminServlet.java
+++ b/src/main/java/com/sourcegraph/admin/AdminServlet.java
@@ -10,7 +10,6 @@ import com.atlassian.templaterenderer.TemplateRenderer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -37,7 +36,7 @@ public class AdminServlet extends HttpServlet {
     }
 
     @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         UserProfile user = userManager.getRemoteUser(request);
         if (user == null || !userManager.isSystemAdmin(user.getUserKey())) {
             redirectToLogin(request, response);

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -49,7 +50,7 @@ public class PermissionRouter {
     /**
      * The getUsersWithRepositoryPermission endpoint returns a roaring bitmap containing the IDs of all the users
      * that is granted the specified permission to the specified repository.
-     *
+     * <p>
      * Ex. /permissions/users?repository=PROJECT_1/rep_1&permission=read
      */
     @GET
@@ -67,7 +68,8 @@ public class PermissionRouter {
 
         Permission permission = getRepositoryPermission(perm);
         if (permission == null) {
-            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
+            return Response.status(Status.UNPROCESSABLE_ENTITY)
+                    .entity("Invalid permission: " + perm + " | Available options: admin, read, write").build();
         }
 
         RoaringBitmap bitmap = new RoaringBitmap();
@@ -87,14 +89,15 @@ public class PermissionRouter {
 
         byte[] backing = serialize(bitmap);
         return backing != null ?
-                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality()).build() :
+                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality())
+                        .entity("Failed roaring bitmap serialization").build() :
                 Response.serverError().build();
     }
 
     /**
      * The getAccessibleRepositories endpoint returns a roaring bitmap containing the IDs of all the repositories
      * that a user is granted the specified permission for.
-     *
+     * <p>
      * Ex. /permissions/repositories?user=user&permission=admin
      */
     @GET
@@ -112,7 +115,8 @@ public class PermissionRouter {
 
         Permission permission = getRepositoryPermission(perm);
         if (permission == null) {
-            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
+            return Response.status(Status.UNPROCESSABLE_ENTITY)
+                    .entity("Invalid permission: " + perm + " | Available options: admin, read, write").build();
         }
 
         EscalatedSecurityContext context = securityService.impersonating(user, "Repository Search");
@@ -136,7 +140,8 @@ public class PermissionRouter {
 
         byte[] backing = serialize(bitmap);
         return backing != null ?
-                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality()).build() :
+                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality())
+                        .entity("Failed roaring bitmap serialization").build() :
                 Response.serverError().build();
     }
 

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -2,8 +2,8 @@ package com.sourcegraph.permission;
 
 import com.atlassian.bitbucket.permission.Permission;
 import com.atlassian.bitbucket.permission.PermissionService;
-import com.atlassian.bitbucket.permission.PermittedGroup;
 import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.repository.RepositorySearchRequest;
 import com.atlassian.bitbucket.repository.RepositoryService;
 import com.atlassian.bitbucket.user.*;
 import com.atlassian.bitbucket.util.Page;
@@ -30,22 +30,19 @@ import java.io.IOException;
 @Component
 public class PermissionRouter {
     @ComponentImport
-    private static UserAdminService userAdminService;
-    @ComponentImport
     private static RepositoryService repositoryService;
     @ComponentImport
     private static UserManager userManager;
     @ComponentImport
-    private static PermissionService permissionService;
-    @ComponentImport
     private static UserService userService;
+    @ComponentImport
+    private static SecurityService securityService;
 
-    public PermissionRouter(UserAdminService users, RepositoryService repositoryService, UserManager userManager, PermissionService permissionService, UserService userService) {
-        PermissionRouter.userAdminService = users;
+    public PermissionRouter(RepositoryService repositoryService, UserManager userManager, UserService userService, SecurityService securityService) {
         PermissionRouter.repositoryService = repositoryService;
         PermissionRouter.userManager = userManager;
-        PermissionRouter.permissionService = permissionService;
         PermissionRouter.userService = userService;
+        PermissionRouter.securityService = securityService;
     }
 
     @GET
@@ -56,20 +53,13 @@ public class PermissionRouter {
             return Response.status(Response.Status.UNAUTHORIZED).build();
         }
 
-        String[] split = repository.split("/");
-        if (split.length < 2) {
-            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
-        }
-
-        Repository repo = repositoryService.getBySlug(split[0], split[1]);
+        Repository repo = getRepository(repository);
         if (repo == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("No such project: " + repository).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("No such repository: " + repository).build();
         }
 
-        Permission perm;
-        try {
-            perm = Permission.valueOf("REPO_" + permission.toUpperCase());
-        } catch (IllegalArgumentException e) {
+        Permission perm = getRepositoryPermission(permission);
+        if (perm == null) {
             return Response.status(Status.UNPROCESSABLE_ENTITY).build();
         }
 
@@ -85,10 +75,56 @@ public class PermissionRouter {
             System.out.println(page.getSize());
             for (ApplicationUser user : page.getValues()) {
                 System.out.println(user.getDisplayName());
-                bitmap.flip(user.getId());
+                bitmap.add(user.getId());
             }
             pageRequest = page.getNextPageRequest();
         } while (pageRequest != null);
+
+        byte[] backing;
+        try {
+            backing = serialize(bitmap);
+        } catch (IOException ex) {
+            return Response.serverError().build();
+        }
+        return Response.ok(backing).build();
+    }
+
+    @GET
+    @Path("/repositories")
+    public Response getAccessibleRepositories(@Context HttpServletRequest request, @QueryParam("user") String name, @QueryParam("permission") String permission) {
+        UserProfile profile = userManager.getRemoteUser(request);
+        if (profile == null || !userManager.isSystemAdmin(profile.getUserKey())) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        ApplicationUser user = userService.getUserByName(name);
+        if (user == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("No such user: " + user).build();
+        }
+
+        Permission perm = getRepositoryPermission(permission);
+        if (perm == null) {
+            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
+        }
+
+        EscalatedSecurityContext context = securityService.impersonating(user, "Repository Search");
+        RoaringBitmap bitmap = context.call(() -> {
+            RoaringBitmap temp = new RoaringBitmap();
+
+            RepositorySearchRequest.Builder builder = new RepositorySearchRequest.Builder();
+            builder.permission(perm);
+            RepositorySearchRequest search = builder.build();
+
+            PageRequest pageRequest = new PageRequestImpl(0, 100);
+            do {
+                Page<Repository> page = repositoryService.search(search, pageRequest);
+                for (Repository repository : page.getValues()) {
+                    temp.add(repository.getId());
+                }
+                pageRequest = page.getNextPageRequest();
+            } while (pageRequest != null);
+            return temp;
+        });
 
         byte[] backing;
         try {
@@ -104,5 +140,19 @@ public class PermissionRouter {
         DataOutputStream out = new DataOutputStream(byteOut);
         bitmap.serialize(out);
         return byteOut.toByteArray();
+    }
+
+    public Repository getRepository(String name) {
+        String[] split = name.split("/");
+        return split.length < 2 ? null : repositoryService.getBySlug(split[0], split[1]);
+    }
+
+    public Permission getRepositoryPermission(String permission) {
+        Permission perm = null;
+        try {
+            perm = Permission.valueOf("REPO_" + permission.toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+        }
+        return perm;
     }
 }

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -46,10 +46,12 @@ public class PermissionRouter {
         PermissionRouter.securityService = securityService;
     }
 
-    // The getUsersWithRepositoryPermission endpoint returns a roaring bitmap containing the IDs of all the users
-    // that is granted the specified permission to the specified repository.
-    //
-    // Ex. /permissions/users?repository=PROJECT_1/rep_1&permission=read
+    /**
+     * The getUsersWithRepositoryPermission endpoint returns a roaring bitmap containing the IDs of all the users
+     * that is granted the specified permission to the specified repository.
+     *
+     * Ex. /permissions/users?repository=PROJECT_1/rep_1&permission=read
+     */
     @GET
     @Path("/users")
     public Response getUsersWithRepositoryPermission(@Context HttpServletRequest request, @QueryParam("repository") String repo, @QueryParam("permission") String perm) throws IOException {
@@ -89,10 +91,12 @@ public class PermissionRouter {
                 Response.serverError().build();
     }
 
-    // The getAccessibleRepositories endpoint returns a roaring bitmap containing the IDs of all the repositories
-    // that a user is granted the specified permission for.
-    //
-    // Ex. /permissions/repositories?user=user&permission=admin
+    /**
+     * The getAccessibleRepositories endpoint returns a roaring bitmap containing the IDs of all the repositories
+     * that a user is granted the specified permission for.
+     *
+     * Ex. /permissions/repositories?user=user&permission=admin
+     */
     @GET
     @Path("/repositories")
     public Response getAccessibleRepositories(@Context HttpServletRequest request, @QueryParam("user") String name, @QueryParam("permission") String perm) {

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -95,15 +95,15 @@ public class PermissionRouter {
      */
     @GET
     @Path("/repositories")
-    public Response getAccessibleRepositories(@Context HttpServletRequest request, @QueryParam("user") String name, @QueryParam("permission") String perm) {
+    public Response getAccessibleRepositories(@Context HttpServletRequest request, @QueryParam("permission") String perm) {
         UserProfile profile = userManager.getRemoteUser(request);
-        if (profile == null || !userManager.isSystemAdmin(profile.getUserKey())) {
+        if (profile == null) {
             return Response.status(Response.Status.UNAUTHORIZED).build();
         }
 
-        ApplicationUser user = userService.getUserByName(name);
+        ApplicationUser user = userService.getUserByName(profile.getUsername());
         if (user == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("No such user: " + name).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("No such user: " + profile.getUsername()).build();
         }
 
         Permission permission = getRepositoryPermission(perm);

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -1,0 +1,105 @@
+package com.sourcegraph.permission;
+
+import com.atlassian.bitbucket.permission.Permission;
+import com.atlassian.bitbucket.permission.PermissionService;
+import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.repository.RepositoryService;
+import com.atlassian.bitbucket.user.DetailedUser;
+import com.atlassian.bitbucket.user.UserAdminService;
+import com.atlassian.bitbucket.util.Page;
+import com.atlassian.bitbucket.util.PageRequest;
+import com.atlassian.bitbucket.util.PageRequestImpl;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import com.sourcegraph.rest.Status;
+import org.roaringbitmap.RoaringBitmap;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+@Path("/permissions")
+@Component
+public class PermissionRouter {
+    @ComponentImport
+    private static UserAdminService userAdminService;
+    @ComponentImport
+    private static RepositoryService repositoryService;
+    @ComponentImport
+    private static UserManager userManager;
+    @ComponentImport
+    private static PermissionService permissionService;
+
+    public PermissionRouter(UserAdminService users, RepositoryService repositoryService, UserManager userManager, PermissionService permissionService) {
+        PermissionRouter.userAdminService = users;
+        PermissionRouter.repositoryService = repositoryService;
+        PermissionRouter.userManager = userManager;
+        PermissionRouter.permissionService = permissionService;
+    }
+
+    @GET
+    @Path("/users")
+    public Response getUsersWithRepositoryPermission(@Context HttpServletRequest request, @QueryParam("repository") String repository, @QueryParam("permission") String permission) throws IOException {
+        UserProfile profile = userManager.getRemoteUser(request);
+        if (profile == null || !userManager.isSystemAdmin(profile.getUserKey())) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        String[] split = repository.split("/");
+        if (split.length < 2) {
+            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
+        }
+
+        Repository repo = repositoryService.getBySlug(split[0], split[1]);
+        if (repo == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("No such project: " + repository).build();
+        }
+
+        Permission perm;
+        try {
+            perm = Permission.valueOf("REPO_" + permission.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return Response.status(Status.UNPROCESSABLE_ENTITY).build();
+        }
+
+        RoaringBitmap bitmap = new RoaringBitmap();
+        PageRequest pageRequest = new PageRequestImpl(0, 100);
+        do {
+            Page<DetailedUser> page = userAdminService.findUsers(pageRequest);
+            for (DetailedUser user : page.getValues()) {
+                if (permissionService.hasRepositoryPermission(user, repo, perm)) {
+                    bitmap.flip(user.getId());
+                }
+            }
+            pageRequest = page.getNextPageRequest();
+        } while (pageRequest != null);
+
+        byte[] backing;
+        try {
+            backing = serialize(bitmap);
+        } catch (IOException ex) {
+            return Response.serverError().build();
+        }
+        return Response.ok(backing).build();
+    }
+
+    public byte[] serialize(RoaringBitmap bitmap) throws IOException {
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(byteOut);
+        bitmap.serialize(out);
+        return byteOut.toByteArray();
+    }
+}

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -78,6 +77,8 @@ public class PermissionRouter {
         builder.repositoryPermission(repository, permission);
         UserSearchRequest search = builder.build();
 
+        // The size of each page in the paginated search is 5000. This is an arbitrarily chosen value
+        // that may require calibration in the future.
         PageRequest pageRequest = new PageRequestImpl(0, 5000);
         do {
             Page<ApplicationUser> page = userService.search(search, pageRequest);
@@ -89,9 +90,8 @@ public class PermissionRouter {
 
         byte[] backing = serialize(bitmap);
         return backing != null ?
-                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality())
-                        .entity("Failed roaring bitmap serialization").build() :
-                Response.serverError().build();
+                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality()).build() :
+                Response.serverError().entity("Failed roaring bitmap serialization").build();
     }
 
     /**
@@ -127,9 +127,12 @@ public class PermissionRouter {
             builder.permission(permission);
             RepositorySearchRequest search = builder.build();
 
+            // The size of each page in the paginated search is 5000. This is an arbitrarily chosen value
+            // that may require calibration in the future.
             PageRequest pageRequest = new PageRequestImpl(0, 5000);
             do {
                 Page<Repository> page = repositoryService.search(search, pageRequest);
+
                 for (Repository repository : page.getValues()) {
                     temp.add(repository.getId());
                 }
@@ -140,9 +143,10 @@ public class PermissionRouter {
 
         byte[] backing = serialize(bitmap);
         return backing != null ?
-                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality())
-                        .entity("Failed roaring bitmap serialization").build() :
-                Response.serverError().build();
+                Response.ok(backing)
+                        .header("X-Debug-Count", bitmap.getCardinality())
+                        .build() :
+                Response.serverError().entity("Failed roaring bitmap serialization").build();
     }
 
     public byte[] serialize(RoaringBitmap bitmap) {

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -14,6 +14,7 @@ import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.sourcegraph.rest.Status;
 import org.roaringbitmap.RoaringBitmap;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
@@ -38,6 +39,7 @@ public class PermissionRouter {
     @ComponentImport
     private static SecurityService securityService;
 
+    @Autowired
     public PermissionRouter(RepositoryService repositoryService, UserManager userManager, UserService userService, SecurityService securityService) {
         PermissionRouter.repositoryService = repositoryService;
         PermissionRouter.userManager = userManager;
@@ -45,6 +47,10 @@ public class PermissionRouter {
         PermissionRouter.securityService = securityService;
     }
 
+    // The getUsersWithRepositoryPermission endpoint returns a roaring bitmap containing the IDs of all the users
+    // that is granted the specified permission to the specified repository.
+    //
+    // Ex. /permissions/users?repository=PROJECT_1/rep_1&permission=read
     @GET
     @Path("/users")
     public Response getUsersWithRepositoryPermission(@Context HttpServletRequest request, @QueryParam("repository") String repository, @QueryParam("permission") String permission) throws IOException {
@@ -87,6 +93,10 @@ public class PermissionRouter {
         return Response.ok(backing).build();
     }
 
+    // The getAccessibleRepositories endpoint returns a roaring bitmap containing the IDs of all the repositories
+    // that a user is granted the specified permission for.
+    //
+    // Ex. /permissions/repositories?user=user&permission=admin
     @GET
     @Path("/repositories")
     public Response getAccessibleRepositories(@Context HttpServletRequest request, @QueryParam("user") String name, @QueryParam("permission") String permission) {

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -75,7 +75,7 @@ public class PermissionRouter {
         builder.repositoryPermission(repository, permission);
         UserSearchRequest search = builder.build();
 
-        PageRequest pageRequest = new PageRequestImpl(0, 100);
+        PageRequest pageRequest = new PageRequestImpl(0, 5000);
         do {
             Page<ApplicationUser> page = userService.search(search, pageRequest);
             for (ApplicationUser user : page.getValues()) {
@@ -118,7 +118,7 @@ public class PermissionRouter {
             builder.permission(permission);
             RepositorySearchRequest search = builder.build();
 
-            PageRequest pageRequest = new PageRequestImpl(0, 100);
+            PageRequest pageRequest = new PageRequestImpl(0, 5000);
             do {
                 Page<Repository> page = repositoryService.search(search, pageRequest);
                 for (Repository repository : page.getValues()) {

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.permission;
 
 import com.atlassian.bitbucket.permission.Permission;
-import com.atlassian.bitbucket.permission.PermissionService;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.repository.RepositorySearchRequest;
 import com.atlassian.bitbucket.repository.RepositoryService;
@@ -61,7 +60,7 @@ public class PermissionRouter {
 
         Repository repository = getRepository(repo);
         if (repository == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("No such repository: " + repository).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("No such repository: " + repo).build();
         }
 
         Permission permission = getRepositoryPermission(perm);
@@ -85,7 +84,9 @@ public class PermissionRouter {
         } while (pageRequest != null);
 
         byte[] backing = serialize(bitmap);
-        return backing != null ? Response.ok(backing).build() : Response.serverError().build();
+        return backing != null ?
+                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality()).build() :
+                Response.serverError().build();
     }
 
     // The getAccessibleRepositories endpoint returns a roaring bitmap containing the IDs of all the repositories
@@ -102,7 +103,7 @@ public class PermissionRouter {
 
         ApplicationUser user = userService.getUserByName(name);
         if (user == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("No such user: " + user).build();
+            return Response.status(Response.Status.NOT_FOUND).entity("No such user: " + name).build();
         }
 
         Permission permission = getRepositoryPermission(perm);
@@ -130,7 +131,9 @@ public class PermissionRouter {
         });
 
         byte[] backing = serialize(bitmap);
-        return backing != null ? Response.ok(backing).build() : Response.serverError().build();
+        return backing != null ?
+                Response.ok(backing).header("X-Debug-Count", bitmap.getCardinality()).build() :
+                Response.serverError().build();
     }
 
     public byte[] serialize(RoaringBitmap bitmap) {

--- a/src/main/java/com/sourcegraph/permission/PermissionRouter.java
+++ b/src/main/java/com/sourcegraph/permission/PermissionRouter.java
@@ -72,9 +72,7 @@ public class PermissionRouter {
         PageRequest pageRequest = new PageRequestImpl(0, 100);
         do {
             Page<ApplicationUser> page = userService.search(search, pageRequest);
-            System.out.println(page.getSize());
             for (ApplicationUser user : page.getValues()) {
-                System.out.println(user.getDisplayName());
                 bitmap.add(user.getId());
             }
             pageRequest = page.getNextPageRequest();


### PR DESCRIPTION
This PR contains a complete and functioning implementation of RFC 45 ACL endpoints via roaring bitmaps.

TODO:
- [ ] ~RFC for technical specification (rest api, etc)~
- [ ] Flush out the PR description
- [ ] Docs

Endpoints:
```
/permissions/users?repository=PROJECT_1%2Frep_1&permission=read
/permissions/repositories?user=user&permission=admin
```

Some numbers:
`https://bitbucket.sgdev.org/rest/sourcegraph-admin/1.0/permissions/repositories?user=milton&permission=read` returns 10k repository ids in 700ms.

This is a part of sourcegraph/sourcegraph#6091.