### PR TITLE
Support build status event webhook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>bitbucket-spi</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-build-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/sourcegraph/webhook/Dispatcher.java
+++ b/src/main/java/com/sourcegraph/webhook/Dispatcher.java
@@ -58,7 +58,6 @@ public class Dispatcher implements Runnable {
 
         JsonObject payload = serializer.serialize();
         String json = new Gson().toJson(payload);
-        System.out.println(json);
         request.setRequestBody(json);
         request.setHeader("X-Hub-Signature", sign(hook.secret, json));
         return request;

--- a/src/main/java/com/sourcegraph/webhook/Dispatcher.java
+++ b/src/main/java/com/sourcegraph/webhook/Dispatcher.java
@@ -58,6 +58,7 @@ public class Dispatcher implements Runnable {
 
         JsonObject payload = serializer.serialize();
         String json = new Gson().toJson(payload);
+        System.out.println(json);
         request.setRequestBody(json);
         request.setHeader("X-Hub-Signature", sign(hook.secret, json));
         return request;

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -4,7 +4,6 @@ import com.atlassian.bitbucket.build.BuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.*;
 import com.atlassian.bitbucket.json.JsonRenderer;
-import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.google.gson.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +20,6 @@ public class EventSerializer {
     private static JsonRenderer renderer;
 
     private ApplicationEvent event;
-    private Repository repository;
     private String name;
     private JsonObject payload;
 

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -1,8 +1,10 @@
 package com.sourcegraph.webhook;
 
+import com.atlassian.bitbucket.build.BuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.*;
 import com.atlassian.bitbucket.json.JsonRenderer;
+import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.google.gson.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,18 +17,28 @@ import java.util.Map;
 @Component
 public class EventSerializer {
     private static final SimpleDateFormat RFC3339 = new SimpleDateFormat("yyyy-MM-dd'T'h:m:ssZZZZZ");
-    private static Map<Class<?>, Adapter> adapters = new HashMap<>();
+    private static Map<String, Adapter> adapters = new HashMap<>();
     private static JsonRenderer renderer;
 
     private ApplicationEvent event;
+    private Repository repository;
     private String name;
     private JsonObject payload;
 
     private static JsonElement render(Object o) {
+        if (o == null) {
+            return null;
+        }
+
         HashMap<String, Object> options = new HashMap<>();
         String raw = renderer.render(o, options);
         return raw == null ? null : new JsonParser().parse(raw);
     }
+
+    private static Adapter<BuildStatusSetEvent> BuildStatusSetEventAdapter = ((element, event) -> {
+        element.addProperty("commit", event.getCommitId());
+        element.add("status", render(event.getBuildStatus()));
+    });
 
     private static Adapter<PullRequestMergeActivityEvent> PullRequestMergeActivityEventAdapter = (element, event) -> {
         JsonObject activity = element.getAsJsonObject("activity");
@@ -40,8 +52,9 @@ public class EventSerializer {
     };
 
     static {
-        adapters.put(PullRequestMergeActivityEvent.class, PullRequestMergeActivityEventAdapter);
-        adapters.put(PullRequestReviewersUpdatedActivityEvent.class, PullRequestReviewersUpdatedActivityEventAdapter);
+        adapters.put("pr:activity:merge", PullRequestMergeActivityEventAdapter);
+        adapters.put("pr:activity:reviewers", PullRequestReviewersUpdatedActivityEventAdapter);
+        adapters.put("repo:build_status", BuildStatusSetEventAdapter);
     }
 
     @Autowired
@@ -61,7 +74,7 @@ public class EventSerializer {
             buildPullRequestEvent((PullRequestActivityEvent) event);
         }
 
-        Adapter adapter = adapters.get(event.getClass());
+        Adapter adapter = adapters.get(this.name);
         if (adapter != null) {
             adapter.apply(payload, event);
         }

--- a/src/main/java/com/sourcegraph/webhook/WebhookListener.java
+++ b/src/main/java/com/sourcegraph/webhook/WebhookListener.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.webhook;
 
+import com.atlassian.bitbucket.build.BuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.*;
 import com.atlassian.bitbucket.repository.Repository;
@@ -10,53 +11,65 @@ import com.sourcegraph.webhook.registry.WebhookRegistry;
 
 import javax.inject.Named;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @AsynchronousPreferred
 @Named("WebhookListener")
 public class WebhookListener {
-    private static Map<Class<?>, List<String>> triggers = new HashMap<>();
 
-    private static void register(Class<?> type, String key) {
-        // Enumerate all prefixes (or super/parent events) of event key.
-        // "pr:comment:added" -> ["pr", "pr:comment", "pr:comment:added"]
+    // getTriggers enumerate all prefixes (or super/parent events) of event key.
+    // "pr:comment:added" -> ["pr", "pr:comment", "pr:comment:added"]
+    public List<String> getTriggers(String key) {
         String[] split = key.split(":");
+        if (split.length == 0) {
+            return null;
+        }
+
         List<String> prefixes = new ArrayList<>();
         for (int i = 0, index = 0; i < split.length; i++) {
             index += split[i].length();
             prefixes.add(key.substring(0, index));
             index++;
         }
-        triggers.put(type, prefixes);
-    }
-
-    static {
-        register(PullRequestActivityEvent.class, "pr:activity:status");
-        register(PullRequestRescopeActivityEvent.class, "pr:activity:rescope");
-        register(PullRequestMergeActivityEvent.class, "pr:activity:merge");
-        register(PullRequestCommentActivityEvent.class, "pr:activity:comment");
-        register(PullRequestReviewersUpdatedActivityEvent.class, "pr:activity:reviewers");
+        return prefixes;
     }
 
     @EventListener
     public void onPullRequestEvent(PullRequestActivityEvent event) {
-        handle(event, event.getPullRequest().getToRef().getRepository());
+        String key = "pr:activity:status";
+        if (event instanceof PullRequestRescopeActivityEvent) {
+            key = "pr:activity:rescope";
+        } else if (event instanceof PullRequestMergeActivityEvent) {
+            key = "pr:activity:merge";
+        } else if (event instanceof PullRequestCommentActivityEvent) {
+            key = "pr:activity:comment";
+        } else if (event instanceof PullRequestReviewersUpdatedActivityEvent) {
+            key = "pr:activity:reviewers";
+        }
+
+        handle(event, key, event.getPullRequest().getToRef().getRepository());
     }
 
-    private void handle(ApplicationEvent event, Repository repository) {
-        List<String> keys = triggers.get(event.getClass());
-        if (keys == null || keys.isEmpty()) {
+    @EventListener
+    public void onBuildStatusEvent(BuildStatusSetEvent event) {
+        handle(event, "repo:build_status");
+    }
+
+    public void handle(ApplicationEvent event, String key) {
+        handle(event, key, null);
+    }
+
+    private void handle(ApplicationEvent event, String key, Repository repository) {
+        List<String> triggers = getTriggers(key);
+        if (triggers == null || triggers.isEmpty()) {
             return;
         }
 
-        List<Webhook> hooks = WebhookRegistry.getWebhooks(keys, repository);
+        List<Webhook> hooks = WebhookRegistry.getWebhooks(triggers, repository);
         if (hooks.isEmpty()) {
             return;
         }
 
-        String key = keys.get(keys.size() - 1);
         EventSerializer serializer = new EventSerializer(key, event);
         hooks.forEach(hook -> Dispatcher.dispatch(hook, serializer));
     }

--- a/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
+++ b/src/main/java/com/sourcegraph/webhook/registry/WebhookRegistry.java
@@ -39,15 +39,18 @@ public class WebhookRegistry {
 
     public static List<Webhook> getWebhooks(List<String> keys, Repository repository) {
         String params = Joiner.on(", ").join(Collections.nCopies(keys.size(), "?"));
-        Iterable<Object> args = Iterables.concat(keys, Arrays.asList(
-                repository.getProject().getId(),
-                repository.getId()
-        ));
+        Iterable<Object> args = Iterables.concat(keys);
 
-        String where = "event.EVENT in (" + params + ") "
-                + "AND (webhook.SCOPE = \'global\' "
-                + "OR (webhook.SCOPE = CONCAT(\'project\', ':',  ?)) "
-                + "OR (webhook.SCOPE = CONCAT(\'repository\', ':', ?)))";
+        String where = "event.EVENT in (" + params + ")";
+        if (repository != null) {
+            where += " AND (webhook.SCOPE = \'global\' "
+                    + "OR (webhook.SCOPE = CONCAT(\'project\', ':',  ?)) "
+                    + "OR (webhook.SCOPE = CONCAT(\'repository\', ':', ?)))";
+            args = Iterables.concat(args, Arrays.asList(
+                    repository.getProject().getName(),
+                    repository.getName()
+            ));
+        }
 
         Query query = Query.select()
                 .alias(WebhookEntity.class, "webhook")


### PR DESCRIPTION
This PR adds support for build status webhooks in the BBS Sourcegraph plugin. This closes sourcegraph/sourcegraph#8386. As noted in the tracking issue, the identifying information exposed by this event is limited. The most we get is the commit ID, so we will have to find a way to correlate this with a specific repository/changeset in the Sourcegraph backend.

This PR also includes some refactoring. Previously, the code was organized in a way that mostly supported pull request events.

This new event is registered under the event key `repo:build_status` which fires when the build status changes. This can be simulated by sending a POST request to the build status BBS REST API.

More context: https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/

Sample payload from BuilldStatusSetEvent:
```
{
  "createdDate": "2020-02-19T1:4:26-0500",
  "user": {
    "name": "admin",
    "emailAddress": "admin@example.com",
    "id": 1,
    "displayName": "Administrator",
    "active": true,
    "slug": "admin",
    "type": "NORMAL",
    "links": {
      "self": [
        {
          "href": "http://localhost:7990/bitbucket/users/admin"
        }
      ]
    },
    "avatarUrl": "https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61.jpg?s=64&d=mm"
  },
  "commit": "797c7fd687ee59edee7a7665341e65b22e8d8bd2",
  "status": {
    "state": "SUCCESSFUL",
    "key": "REPO-MASTER",
    "name": "REPO-MASTER-42",
    "url": "https://bamboo.example.com/browse/REPO-MASTER-42",
    "description": "Changes by John Doe",
    "dateAdded": 1582092266068
  }
}

```