### PR TITLE
Add release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ If a user is not logged in to Sourcegraph, they will still see the "View Reposit
 -   `atlas-help` -- prints description for all commands in the SDK
 
 See also the Atlassian Plugin SDK [documentation](https://developer.atlassian.com/display/DOCS/Introduction+to+the+Atlassian+Plugin+SDK).
+
+## Releasing
+
+To release a version of the plugin, run `./scripts/release.sh <CURRENT VERSION> <NEW VERSION>`. This script uploads a new version of the plugin jar to google cloud. There are two requirements for this script to work being: (1) atlassian sdk installed and (2) gcloud cli set up with the sourcegraph-dev project.Ex:
+```
+./scripts/release.sh 1.1.0 1.2.0
+```
+The new version should be the one specified in `pom.xml`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,6 +13,8 @@
 #
 # ex: ./scripts/release.sh 1.1.0 1.2.0
 
+set -e
+
 rm -rf ./target/
 atlas-package
 gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-bitbucket-server/${1}.jar

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,6 @@
 # 2) gcloud cli setup with sourcegraph-dev project (for uploading jar)
 #
 # This script is to be run in the root folder.
-# It is to be run with two arguments:
 #
 # ./scripts/release.sh <OLD VERSION> <NEW VERSION>
 #

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,4 +19,5 @@ gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-
 gsutil cp ./target/sourcegraph-bitbucket-${2}.jar gs://sourcegraph-for-bitbucket-server/latest.jar
 
 # Allow anyone to download
+gsutil acl ch -u AllUsers:R gs://sourcegraph-for-bitbucket-server/${1}.jar
 gsutil acl ch -u AllUsers:R gs://sourcegraph-for-bitbucket-server/latest.jar

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,6 +13,7 @@
 #
 # ex: ./scripts/release.sh 1.1.0 1.2.0
 
+rm -rf ./target/
 atlas-package
 gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-bitbucket-server/${1}.jar
 gsutil cp ./target/sourcegraph-bitbucket-${2}.jar gs://sourcegraph-for-bitbucket-server/latest.jar

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,8 +15,8 @@
 # ex: ./scripts/release.sh 1.1.0 1.2.0
 
 atlas-package
-gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-bitbucket-server/${0}.jar
-gsutil mv ./target/sourcegraph-bitbucket-${1}.jar gs://sourcegraph-for-bitbucket-server/latest.jar
+gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-bitbucket-server/${1}.jar
+gsutil cp ./target/sourcegraph-bitbucket-${2}.jar gs://sourcegraph-for-bitbucket-server/latest.jar
 
 # Allow anyone to download
 gsutil acl ch -u AllUsers:R gs://sourcegraph-for-bitbucket-server/latest.jar

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,22 @@
+# This script cuts and uploads a release JAR to
+# our google cloud storage.
+#
+# https://storage.googleapis.com/sourcegraph-for-bitbucket-server/latest.jar
+#
+# The dependencies are:
+# 1) atlassian sdk (for building jar)
+# 2) gcloud cli setup with sourcegraph-dev project (for uploading jar)
+#
+# This script is to be run in the root folder.
+# It is to be run with two arguments:
+#
+# ./scripts/release.sh <OLD VERSION> <NEW VERSION>
+#
+# ex: ./scripts/release.sh 1.1.0 1.2.0
+
+atlas-package
+gsutil mv gs://sourcegraph-for-bitbucket-server/latest.jar gs://sourcegraph-for-bitbucket-server/${0}.jar
+gsutil mv ./target/sourcegraph-bitbucket-${1}.jar gs://sourcegraph-for-bitbucket-server/latest.jar
+
+# Allow anyone to download
+gsutil acl ch -u AllUsers:R gs://sourcegraph-for-bitbucket-server/latest.jar


### PR DESCRIPTION
This PR adds a minimal release script. It produces the plugin jar and uploads it to our google cloud storage bucket.

It's a WIP. Git tagging will likely be added. The release process isn't determined at the moment. I'm also considering doing all of this in a CI process.