### PR TITLE
Listen for PullRequestEvents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -15,12 +15,9 @@ import com.google.gson.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.awt.*;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
 public class EventSerializer {

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -115,7 +115,7 @@ public class EventSerializer {
     }
 
     private void buildApplicationEvent(ApplicationEvent event) {
-        payload.addProperty("createdDate", RFC3339.format(event.getDate()));
+        payload.addProperty("createdDate", event.getDate().toInstant().toEpochMilli());
         payload.add("user", render(event.getUser()));
     }
 

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -3,6 +3,7 @@ package com.sourcegraph.webhook;
 import com.atlassian.bitbucket.build.BuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestActivityEvent;
+import com.atlassian.bitbucket.event.pull.PullRequestEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestMergeActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestReviewersUpdatedActivityEvent;
 import com.atlassian.bitbucket.json.JsonRenderer;
@@ -89,8 +90,13 @@ public class EventSerializer {
 
     public JsonObject serialize() {
         buildApplicationEvent(this.event);
+
+        if (event instanceof PullRequestEvent) {
+            buildPullRequestEvent((PullRequestEvent) event);
+        }
+
         if (event instanceof PullRequestActivityEvent) {
-            buildPullRequestEvent((PullRequestActivityEvent) event);
+            buildPullRequestActivityEvent((PullRequestActivityEvent) event);
         }
 
         Adapter adapter = adapters.get(this.name);
@@ -113,8 +119,12 @@ public class EventSerializer {
         payload.add("user", render(event.getUser()));
     }
 
-    private void buildPullRequestEvent(PullRequestActivityEvent event) {
+    private void buildPullRequestEvent(PullRequestEvent event) {
         payload.add("pullRequest", render(event.getPullRequest()));
+        payload.addProperty("action", event.getAction().toString());
+    }
+
+    private void buildPullRequestActivityEvent(PullRequestActivityEvent event) {
         payload.add("activity", render(event.getActivity()));
     }
 

--- a/src/main/java/com/sourcegraph/webhook/WebhookListener.java
+++ b/src/main/java/com/sourcegraph/webhook/WebhookListener.java
@@ -59,10 +59,9 @@ public class WebhookListener {
             key =  "pr:participant:status";
         }
 
-        if (event instanceof  PullRequestActivityEvent) {
+        if (event instanceof PullRequestActivityEvent) {
             key = "pr:activity:event";
         }
-
         if (event instanceof PullRequestRescopeActivityEvent) {
             key = "pr:activity:rescope";
         } else if (event instanceof PullRequestMergeActivityEvent) {


### PR DESCRIPTION
Instead of PullRequestActivityEvents

Also, ensure we don't fire both Activity and Pull Request events apart from the move from Needs Work to Unapproved.

Part of: https://github.com/sourcegraph/sourcegraph/issues/9139