### PR TITLE
Update: add build dependency and rename unique key

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1674666249553</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
-        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}.server</atlassian.plugin.key>
 
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
         <javax.inject.version>1</javax.inject.version>
@@ -129,6 +129,11 @@
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-build-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
RE [Issue](https://github.com/orgs/sourcegraph/projects/316/views/1?pane=issue&itemId=18599042)

This PR updates the bitbucket plugin key from `com.sourcegraph.plugins.sourcegraph-bitbucket` to `com.sourcegraph.plugins.sourcegraph-bitbucket.server` due to app key not unique when submitting to the marketplace.

The current build fails with the errors shown below as the compiler is unable to find the `javax.xml.bind.annotation` package. Adding the dependency for the jaxb-api library to pom.xml fixed the issue and I was able to create a new package with the new key.

The new package has been uploaded to our google bucket for the marketplace submission process: https://storage.googleapis.com/sourcegraph-for-bitbucket-server/latest-server.jar

```sh
[INFO] 8 errors
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:28 min
[INFO] Finished at: 2023-01-25T08:44:49-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project sourcegraph-bitbucket: Compilation failure: Compilation failure:
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[13,33] package javax.xml.bind.annotation does not exist
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[14,33] package javax.xml.bind.annotation does not exist
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[15,33] package javax.xml.bind.annotation does not exist
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[16,33] package javax.xml.bind.annotation does not exist
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[31,6] cannot find symbol
[ERROR]   symbol:   class XmlRootElement
[ERROR]   location: class com.sourcegraph.admin.ConfigResource
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[32,6] cannot find symbol
[ERROR]   symbol:   class XmlAccessorType
[ERROR]   location: class com.sourcegraph.admin.ConfigResource
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[32,22] cannot find symbol
[ERROR]   symbol:   variable XmlAccessType
[ERROR]   location: class com.sourcegraph.admin.ConfigResource
[ERROR] /Users/bwork/dev/intergrations/bitbucket-server-plugin/src/main/java/com/sourcegraph/admin/ConfigResource.java:[34,10] cannot find symbol
[ERROR]   symbol:   class XmlElement
[ERROR]   location: class com.sourcegraph.admin.ConfigResource.Config
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```