### PR TITLE
Support Bitbucket Server v8

### DIFF
--- a/.project
+++ b/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1674666249553</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1683013192691</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
-        <atlassian.plugin.key>${project.groupId}.${project.artifactId}.server</atlassian.plugin.key>
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
         <javax.inject.version>1</javax.inject.version>
@@ -129,11 +129,6 @@
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-build-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>1.3.7</version>
+    <version>2.0.0</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <amps.version>8.0.0</amps.version>
-        <bitbucket.version>5.16.0</bitbucket.version>
+        <bitbucket.version>8.9.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
@@ -128,6 +128,7 @@
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-build-api</artifactId>
+            <version>7.21.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.webhook;
 
-import com.atlassian.bitbucket.build.BuildStatusSetEvent;
+import com.atlassian.bitbucket.build.status.RepositoryBuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestEvent;
@@ -43,12 +43,12 @@ public class EventSerializer {
         return raw == null ? null : new JsonParser().parse(raw);
     }
 
-    private static Adapter<BuildStatusSetEvent> BuildStatusSetEventAdapter = ((element, event) -> {
-        element.addProperty("commit", event.getCommitId());
+    private static Adapter<RepositoryBuildStatusSetEvent> RepositoryBuildStatusSetEventAdapter = ((element, event) -> {
+        element.addProperty("commit", event.getBuildStatus().getCommitId());
         element.add("status", render(event.getBuildStatus()));
 
         // Find Pull Requests
-        PullRequestCommitSearchRequest searchRequest = new PullRequestCommitSearchRequest.Builder(event.getCommitId()).build();
+        PullRequestCommitSearchRequest searchRequest = new PullRequestCommitSearchRequest.Builder(event.getBuildStatus().getCommitId()).build();
         PageProvider<PullRequest> pager = (pageRequest) -> pullRequestService.searchByCommit(searchRequest, pageRequest);
 
         JsonArray ja = new JsonArray();
@@ -73,7 +73,7 @@ public class EventSerializer {
     static {
         adapters.put("pr:activity:merge", PullRequestMergeActivityEventAdapter);
         adapters.put("pr:activity:reviewers", PullRequestReviewersUpdatedActivityEventAdapter);
-        adapters.put("repo:build_status", BuildStatusSetEventAdapter);
+        adapters.put("repo:build_status", RepositoryBuildStatusSetEventAdapter);
     }
 
     @Autowired

--- a/src/main/java/com/sourcegraph/webhook/WebhookListener.java
+++ b/src/main/java/com/sourcegraph/webhook/WebhookListener.java
@@ -1,10 +1,9 @@
 package com.sourcegraph.webhook;
 
-import com.atlassian.bitbucket.build.BuildStatusSetEvent;
+import com.atlassian.bitbucket.build.status.RepositoryBuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.*;
 import com.atlassian.bitbucket.pull.PullRequestAction;
-import com.atlassian.bitbucket.pull.PullRequestParticipant;
 import com.atlassian.bitbucket.pull.PullRequestParticipantStatus;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.event.api.AsynchronousPreferred;
@@ -77,7 +76,7 @@ public class WebhookListener {
     }
 
     @EventListener
-    public void onBuildStatusEvent(BuildStatusSetEvent event) {
+    public void onRepositoryBuildStatusSetEvent(RepositoryBuildStatusSetEvent event) {
         handle(event, "repo:build_status");
     }
 


### PR DESCRIPTION
Release new Sourcegraph for Bitbucket Server plugin version supporting Bitbucket Server v8.0

Refactors `BuildStatusSetEvent` usages to `RepositoryBuildStatusSetEvent` as the former has been deprecated ([docs](https://docs.atlassian.com/bitbucket-server/javadoc/7.6.0/api/com/atlassian/bitbucket/build/BuildStatusSetEvent.html)). 

[Slack thread](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1682453550734469)

<img width="390" alt="Screenshot 2023-05-02 at 09 47 10" src="https://user-images.githubusercontent.com/25318659/235598889-f6a81fb4-fb43-4d9b-a188-f9157ba19ac9.png">
<img width="1038" alt="Screenshot 2023-05-02 at 09 51 55" src="https://user-images.githubusercontent.com/25318659/235599200-55665652-d82b-4dcb-8af6-ea4a00fc27e1.png">
<img width="1456" alt="Screenshot 2023-05-02 at 09 49 28" src="https://user-images.githubusercontent.com/25318659/235598891-aac669a6-3553-405c-8080-8f8329fb9e7d.png">
