### PR TITLE
Partially revert "Add dependency and rename unique key (#35)"

### DIFF
--- a/.project
+++ b/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1674666249553</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1683013192691</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
 
         <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
-        <atlassian.plugin.key>${project.groupId}.${project.artifactId}.server</atlassian.plugin.key>
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
 
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
         <javax.inject.version>1</javax.inject.version>
@@ -129,11 +129,6 @@
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-build-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>


### PR DESCRIPTION
I compared MANIFEST.MF files of https://github.com/sourcegraph/bitbucket-server-plugin/commit/7b4389039fa9930e32d344f9747c170e98d9dac9 and https://github.com/sourcegraph/bitbucket-server-plugin/commit/97fc6d39f406b100359ee5e22cc3bee9d1453df8 (pre- and post #35) plugin builds and it had diff in the following fields:
- Import-Package: `com.sun.activation.registries` was added in the latter
- Require-Capability: The former requires JavaSE version `1.8`, while the latter - `9.0`.
This difference in Java versions broke the local plugin build and couldn't be enabled on the local Bitbucket instance.

The plugin key change introduced in #35 is not needed as the plugin is not going to be published in the marketplace at the moment (see this [issue](https://github.com/orgs/sourcegraph/projects/316/views/1?pane=issue&itemId=18599042)).

I confirm that Sourcegraph plugin for Bitbucket Server is enabled for the local instance.
<img width="408" alt="Screenshot 2023-05-02 at 10 07 40" src="https://user-images.githubusercontent.com/25318659/235603708-3e8586de-66ee-4fe8-9472-70bd082f2cd4.png">
<img width="1040" alt="Screenshot 2023-05-02 at 10 17 01" src="https://user-images.githubusercontent.com/25318659/235603714-22d128c0-b6b9-4f2e-a54a-d33de38350b3.png">

