### PR TITLE
Cleanup extension a little and fix repository push webhooks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,62 @@
+# Local Development
+
+Due some older dependencies, you'll need develop using Java 8. To install on MacOS, do the following:
+
+```
+brew install --cask temurin@8
+```
+
+In order to develop locally you will need to install the [Atlassian Plugin SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/downloads/), note that it supports installation via Homebrew on MacOS:
+
+```bash
+brew tap atlassian/tap
+brew install atlassian/tap/atlassian-plugin-sdk
+```
+
+Don't forget to set you `JAVA_HOME` environment variable for Java 8. On MacOS you can see your Java installations with the following command:
+
+```aidl
+/usr/libexec/java_home -V
+```
+
+If using IntelliJ you'll need to configure it to use the Atlassian version of Maven. Find your settings.xml file:
+
+```text
+atlas-version
+```
+
+Look for the line ending in `settings.xml`, copy the directory.
+
+In IntelliJ, navigate to Preferences -> Build, Execution, Deployment -> Build Tools -> Maven
+
+Override `User Settings File` with the directory you copied above. 
+
+The following commands are also useful for local development:
+
+- `atlas-run` -- installs this plugin into the product and starts it on localhost (`--context-path /` will run it on [http://localhost:7990](http://localhost:7990) instead of [http://localhost:7990/bitbucket](http://localhost:7990/bitbucket))
+- `atlas-debug` -- same as atlas-run, but allows a debugger to attach at port 5005
+- `atlas-help` -- prints description for all commands in the SDK
+
+See also the Atlassian Plugin SDK [documentation](https://developer.atlassian.com/display/DOCS/Introduction+to+the+Atlassian+Plugin+SDK).
+
+The default credentials are `admin/admin` for the `atlas-run` environment.
+
+## Attaching a debugger
+
+As mentioned above, running `atlas-debug` will run in debug mode. In order to attach a debugger using IntelliJ follow these steps:
+
+1. Run -> Debug -> Edit Configuration
+1. Click `+` and select `Remote`
+1. The default settings should work, just name it for example `Bitbucket`
+1. Run -> Debug, select the name you used above
+1. The console should say that it has attached and you can add breakpoints etc 
+
+# Releasing
+
+To release a version of the plugin, run `./scripts/release.sh <CURRENT VERSION> <NEW VERSION>`. This script uploads a new version of the plugin jar to google cloud. There are two requirements for this script to work being: (1) atlassian sdk installed and (2) gcloud cli set up with the sourcegraph-dev project.
+
+```
+./scripts/release.sh 1.1.0 1.2.0
+```
+
+The new version should be the one specified in `pom.xml`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
 # Sourcegraph for Bitbucket Server
 
-The Sourcegraph plugin for Bitbucket Server communicates with your Sourcegraph instance to add **code intelligence** to your Bitbucket Server code views and pull requests. The plugin also has the optional functionality to enable **faster ACL permission syncing between Sourcegraph and Bitbucket Server** and can add **webhooks with configurable scope to Bitbucket Server**.
+The Sourcegraph plugin for Bitbucket Server communicates with your Sourcegraph instance to add **code intelligence** to your Bitbucket Server code views and pull requests.
+
+The plugin also has the optional functionality to enable **faster ACL permission syncing between Sourcegraph and Bitbucket Server** and can add **webhooks with configurable scope to Bitbucket Server**.
 
 ## Installation and Usage
 
 ### Prerequisites
 
-1. You must have a self-hosted Sourcegraph instance set up, v3.6 or higher.
-2. Your Sourcegraph instance should have a Bitbucket Server [external service](https://docs.sourcegraph.com/admin/external_service/bitbucket_server) configured.
-3. The `corsOrigin` property should be set in [site configuration](https://docs.sourcegraph.com/admin/config/site_config) to include the URL of your Bitbucket Server instance. Example value:
+1. You must have a Cloud or self-hosted Sourcegraph instance set up on v3.6 or higher.
+2. Your Sourcegraph instance should have a Bitbucket Server [code host connection](https://sourcegraph.com/docs/admin/code_hosts/bitbucket_server) configured.
+3. The `corsOrigin` property should be set in [site configuration](https://sourcegraph.com/docs/admin/config/site_config) to include the URL of your Bitbucket Server instance. Example value:
 
 ```json
-    "corsOrigin": "https://bitbucket.internal.org"
+    "corsOrigin": "https://bitbucket.example.com"
 ```
 
 ### Installation
+
+#### Via the [Atlassian marketplace](https://marketplace.atlassian.com/apps/1231975/sourcegraph-for-bitbucket?hosting=datacenter&tab=pricing)
+
+1. Log into your Bitbucket instance as an admin.
+2. Click the admin dropdown and choose Add-ons.
+3. Click Find new apps or Find new add-ons from the left-hand side of the page.
+4. Locate "Sourcegraph for Bitbucket" via search.
+5. Click Install to download and install your app.
+
+#### Via file upload
 
 1. Log in to Bitbucket Server as an admin.
 2. Navigate to the Bitbucket admin page.
@@ -28,18 +40,24 @@ https://storage.googleapis.com/sourcegraph-for-bitbucket-server/latest.jar
 
 ### Updating
 
+#### Via the Atlassian marketplace
+
+Installing the Sourcegraph for Bitbucket Server via the Atlassian marketplace will automatically update the plugin to the latest version, if enabled, and offer new versions to administrators in the UI.
+
+#### Via file upload
+
 Follow the steps in [Installation](#installation).
 
 ### Configuration
 
-After installing the Sourcegraph for Bitbucket Server, you should configure it to point to your Sourcegraph instance.
+After installing the Sourcegraph for Bitbucket Server, you need to configure it to point to your Sourcegraph instance.
 
 1. On Bitbucket, go to the **Administration** page
 2. Find the **Sourcegraph** entry under **Add-ons**:
 
 <img src="img/add-ons.png" alt="Add-ons" width="400px"/>
 
-3. On the **Sourcegraph Settings** page, set the Sourcegraph URL to the URL of your self-hosted Sourcegraph instance:
+3. On the **Sourcegraph Settings** page, set the Sourcegraph URL to the URL of your Sourcegraph instance:
 
 <img src="img/sourcegraph-settings.png" alt="Sourcegraph settings" width="400px"/>
 
@@ -69,62 +87,3 @@ Sourcegraph for Bitbucket Server adds two REST endpoints to provide more efficie
 - `/permissions/users?repository=<REPO>&permission=<PERMISSION_LEVEL>`<br /> Returns **a list of user IDs** that have access to the given `repository` on the given `permission` level.
 
 The lists returned by both endpoints are encoded as [Roaring Bitmaps](https://roaringbitmap.org/).
-
-## Local Development
-
-In order to develop locally you will need to install the [Atlassian Plugin SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/downloads/), note that it supports installation via Homebrew on MacOS.
-
-Due some older dependencies, you'll need develop using Java 8. To install on MacOS, do the following:
-
-```
-brew tap AdoptOpenJDK/openjdk
-brew cask install adoptopenjdk8-openj9
-```
-
-Don't forget to set you `JAVA_HOME` environment variable for Java 8. On MacOS you can see your Java installations with the following command:
-
-```aidl
-/usr/libexec/java_home -V
-```
-
-If using IntelliJ you'll need to configure it to use the Atlassian version of Maven. Find your settings.xml file:
-
-```text
-atlas-version
-```
-
-Look for the line ending in `settings.xml`, copy the directory.
-
-In IntelliJ, navigate to Preferences -> Build, Execution, Deployment -> Build Tools -> Maven
-
-Override `User Settings File` with the directory you copied above. 
-
-The following commands are also useful for local development:
-
--   `atlas-run` -- installs this plugin into the product and starts it on localhost (`--context-path /` will run it on [http://localhost:7990](http://localhost:7990) instead of [http://localhost:7990/bitbucket](http://localhost:7990/bitbucket))
--   `atlas-debug` -- same as atlas-run, but allows a debugger to attach at port 5005
--   `atlas-help` -- prints description for all commands in the SDK
-
-See also the Atlassian Plugin SDK [documentation](https://developer.atlassian.com/display/DOCS/Introduction+to+the+Atlassian+Plugin+SDK).
-
-The default credentials are `admin/admin` for the `atlas-run` environment.
-
-### Attaching a debugger
-
-As mentioned above, running `atlas-debug` will run in debug mode. In order to attach a debugger using IntelliJ follow these steps:
-
-1. Run -> Debug -> Edit Configuration
-1. Click `+` and select `Remote`
-1. The default settings should work, just name it for example `Bitbucket`
-1. Run -> Debug, select the name you used above
-1. The console should say that it has attached and you can add breakpoints etc 
-
-## Releasing
-
-To release a version of the plugin, run `./scripts/release.sh <CURRENT VERSION> <NEW VERSION>`. This script uploads a new version of the plugin jar to google cloud. There are two requirements for this script to work being: (1) atlassian sdk installed and (2) gcloud cli set up with the sourcegraph-dev project.
-
-```
-./scripts/release.sh 1.1.0 1.2.0
-```
-
-The new version should be the one specified in `pom.xml`.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sourcegraph.plugins</groupId>
     <artifactId>sourcegraph-bitbucket</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Sourcegraph for Bitbucket Server</name>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
     </dependencyManagement>
 
     <dependencies>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
+      </dependency>
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>

--- a/src/main/java/com/sourcegraph/webhook/EventSerializer.java
+++ b/src/main/java/com/sourcegraph/webhook/EventSerializer.java
@@ -6,6 +6,7 @@ import com.atlassian.bitbucket.event.pull.PullRequestActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestMergeActivityEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestReviewersUpdatedActivityEvent;
+import com.atlassian.bitbucket.event.repository.RepositoryPushEvent;
 import com.atlassian.bitbucket.json.JsonRenderer;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestCommitSearchRequest;
@@ -99,6 +100,10 @@ public class EventSerializer {
             buildPullRequestActivityEvent((PullRequestActivityEvent) event);
         }
 
+        if (event instanceof RepositoryPushEvent) {
+            buildRepositoryPushEvent((RepositoryPushEvent) event);
+        }
+
         Adapter adapter = adapters.get(this.name);
         if (adapter != null) {
             adapter.apply(payload, event);
@@ -122,6 +127,11 @@ public class EventSerializer {
     private void buildPullRequestEvent(PullRequestEvent event) {
         payload.add("pullRequest", render(event.getPullRequest()));
         payload.addProperty("action", event.getAction().toString());
+    }
+
+    private void buildRepositoryPushEvent(RepositoryPushEvent event) {
+        payload.add("repository", render(event.getRepository()));
+        payload.add("refChanges", render(event.getRefChanges()));
     }
 
     private void buildPullRequestActivityEvent(PullRequestActivityEvent event) {

--- a/src/main/java/com/sourcegraph/webhook/README.md
+++ b/src/main/java/com/sourcegraph/webhook/README.md
@@ -1,7 +1,9 @@
 # Webhooks
+
 The Sourcegraph Bitbucket Server plugin provides an implementation for webhooks that supports listening to events at a global or project scope.
 
 ## Contents
+
 - [Payload](#payload)
 - [REST API](#rest-api)
     * [List](#list)
@@ -9,9 +11,11 @@ The Sourcegraph Bitbucket Server plugin provides an implementation for webhooks 
     * [Delete](#delete)
 
 ## Payload
+
 The event payload HTTP POST request is sent when an event is fired. In the case that the request fails, there will be four further attempts with an interval of 10 seconds before it stops trying. The outcomes of these requests are recorded in the logs.
 
 Each request has the following headers:
+
 - `X-Event-Key` - The name of the event
 - `X-Hook-ID` - The ID that represents the webhook
 - `X-Hook-Name` - The name of the webhook that sends the request
@@ -19,8 +23,8 @@ Each request has the following headers:
 
 The payload is sent in the request body as a JSON object. Each payload follows the schema specified in [Event Payload](https://confluence.atlassian.com/bitbucketserver0516/event-payload-966061436.html?utm_campaign=in-app-help&utm_medium=in-app-help&utm_source=stash#Eventpayload-repositoryevents) and [Bitbucket Entities](https://docs.atlassian.com/bitbucket-server/docs/5.16.0/reference/javascript/JSON.html).
 
-
 Here is an example payload for the event `pr:opened`:
+
 ```
 2019/11/20 22:31:54 POST / HTTP/1.1                             
 Host: localhost:4000                                            
@@ -60,55 +64,138 @@ c7d89f26bd1972efa854d13d7dd61.jpg?s\u003d64\u0026d\u003dmm"},"role":"AUTHOR","ap
 ]}}}
 ```
 
+Example payload for `repo:refs_changed`:
+
+```json
+{
+  "createdDate": 1717777064737,
+  "user": {
+    "name": "admin",
+    "emailAddress": "admin@example.com",
+    "active": true,
+    "displayName": "Administrator",
+    "id": 2,
+    "slug": "admin",
+    "type": "NORMAL",
+    "links": { "self": [{ "href": "http://localhost:7990/users/admin" }] },
+    "avatarUrl": "https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61.jpg?s\u003d64\u0026d\u003dmm"
+  },
+  "repository": {
+    "slug": "rep_1",
+    "id": 1,
+    "name": "rep_1",
+    "hierarchyId": "2bba4665b20d5005be17",
+    "scmId": "git",
+    "state": "AVAILABLE",
+    "statusMessage": "Available",
+    "forkable": true,
+    "project": {
+      "key": "PROJECT_1",
+      "id": 1,
+      "name": "Project 1",
+      "description": "Default configuration project #1",
+      "public": false,
+      "type": "NORMAL",
+      "links": {
+        "self": [{ "href": "http://localhost:7990/projects/PROJECT_1" }]
+      },
+      "avatarUrl": "/projects/PROJECT_1/avatar.png?s\u003d64\u0026v\u003d1681176287106"
+    },
+    "public": false,
+    "archived": false,
+    "links": {
+      "clone": [
+        {
+          "href": "http://localhost:7990/scm/project_1/rep_1.git",
+          "name": "http"
+        },
+        {
+          "href": "ssh://git@localhost:7999/project_1/rep_1.git",
+          "name": "ssh"
+        }
+      ],
+      "self": [
+        {
+          "href": "http://localhost:7990/projects/PROJECT_1/repos/rep_1/browse"
+        }
+      ]
+    }
+  },
+  "refChanges": [
+    {
+      "ref": {
+        "id": "refs/heads/master",
+        "displayId": "master",
+        "type": "BRANCH"
+      },
+      "refId": "refs/heads/master",
+      "fromHash": "e54a46d4e4ddb7bb370070aa8a9b68e0ed959e5b",
+      "toHash": "b14f55bd2b206c1128676131f9d66c56ec19e388",
+      "type": "UPDATE"
+    }
+  ]
+}
+```
+
 ## REST API
+
 Interacting with the webhook REST endpoints requires [authentication](https://developer.atlassian.com/server/bitbucket/how-tos/example-basic-authentication/) from a system admin account. Otherwise, requests will result in `401`s.
 
-#### List
-```
+### List
+
+```bash
 $ curl -X GET 'https://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook'
 ```
+
 There will be a 200 response code if successful.
 
 Output: JSON serialized `[]Webhook`  
-```
+
+```json
 [{
     "id": "1",
     "name": "webhook",
     "scope": "global",
     "events": ["pr"],
-    "endpoint": "https://${SOURCEGRAPH_URL}/.api/bitbucket-server-webhooks",
+    "endpoint": "https://${SOURCEGRAPH_URL}/.api/webhooks/54104dbb-0b71-4a83-aa6b-eef46241614a",
     "secret": "secret"
 }]
 ```
 
-#### Create
-```
-curl -X POST 'https://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook' \
+### Create
+
+```bash
+$ curl -X POST 'https://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook' \
     -H 'Content-Type: application/json' \
     -d '{"name":"sourcegraph-webhook", "scope":"global", "events":["pr"], "endpoint":"https://sourcegraph.example.com/.api/bitbucket-server-webhooks", "secret":"verylongsecret"}'
 ```
+
 There will be a 204 response code if successful.  
 
 **JSON Fields:**
-* name - string id for webhook
-* scope - can be either `global`, `project:<project name>`, or `repository:<project key>/<repository name>`
-* events - list of events; events can be: `pr`, `pr:opened`, `pr:modified`, `pr:reviewer`, `pr:reviewer:updated`, `pr:reviewer:approved`, `pr:reviewer:unapproved`, `pr:reviewer:needs_work`, `pr:merged`, `pr:declined`, `pr:deleted`, `pr:comment`, `pr:comment:added`, `pr:comment:edited`, `pr:comment:deleted`
-* endpoint - url that the event payload will be sent to
-* secret - key to sign payload request with
 
-Error codes:  
+- name - string id for webhook
+- scope - can be either `global`, `project:<project name>`, or `repository:<project key>/<repository name>`
+- events - list of events; events can be: `pr`, `pr:opened`, `pr:modified`, `pr:reviewer`, `pr:reviewer:updated`, `pr:reviewer:approved`, `pr:reviewer:unapproved`, `pr:reviewer:needs_work`, `pr:merged`, `pr:declined`, `pr:deleted`, `pr:comment`, `pr:comment:added`, `pr:comment:edited`, `pr:comment:deleted`
+- endpoint - url that the event payload will be sent to
+- secret - key to sign payload request with
+
+Error codes:
 `404` - No such project or repository  
 `422` - Invalid scope
 
 NOTE: More events can be added in the future. These are just the currently supported ones.
 
-#### Delete
-```
-curl -X DELETE http://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook \
+### Delete
+
+```bash
+$ curl -X DELETE http://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook \
     -d 'name=<name>'
 ```
-```
-curl -X DELETE http://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook \
+
+```bash
+$ curl -X DELETE http://${BITBUCKET_SERVER_URL}/rest/sourcegraph-admin/1.0/webhook \
     -d 'id=<id>'
 ```
+
 There will be a 204 response code if successful.

--- a/src/main/java/com/sourcegraph/webhook/WebhookListener.java
+++ b/src/main/java/com/sourcegraph/webhook/WebhookListener.java
@@ -3,6 +3,7 @@ package com.sourcegraph.webhook;
 import com.atlassian.bitbucket.build.status.RepositoryBuildStatusSetEvent;
 import com.atlassian.bitbucket.event.ApplicationEvent;
 import com.atlassian.bitbucket.event.pull.*;
+import com.atlassian.bitbucket.event.repository.RepositoryPushEvent;
 import com.atlassian.bitbucket.pull.PullRequestAction;
 import com.atlassian.bitbucket.pull.PullRequestParticipantStatus;
 import com.atlassian.bitbucket.repository.Repository;
@@ -18,7 +19,6 @@ import java.util.List;
 @AsynchronousPreferred
 @Named("WebhookListener")
 public class WebhookListener {
-
     // getTriggers enumerate all prefixes (or super/parent events) of event key.
     // "pr:comment:added" -> ["pr", "pr:comment", "pr:comment:added"]
     public List<String> getTriggers(String key) {
@@ -78,6 +78,11 @@ public class WebhookListener {
     @EventListener
     public void onRepositoryBuildStatusSetEvent(RepositoryBuildStatusSetEvent event) {
         handle(event, "repo:build_status");
+    }
+
+    @EventListener
+    public void onRepositoryPushEvent(RepositoryPushEvent event) {
+        handle(event, "repo:refs_changed");
     }
 
     public void handle(ApplicationEvent event, String key) {

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -14,6 +14,7 @@
                 </div>
             </div>
         </header>
+        <h3>Code intelligence setup</h3>
         <p>
             Connect Bitbucket to your Sourcegraph instance to get code intelligence on code views and pull requests.
         </p>
@@ -100,7 +101,7 @@
                 <div class="description">
                     This is the URL to the webhook endpoint of your Sourcegraph instance.
                     <br>
-                    Example: <b>https://sourcegraph.internal.org/.api/bitbucket-server-webhooks</b>
+                    Example: <b>https://sourcegraph.example.com/.api/webhooks/54104dbb-0b71-4a83-aa6b-eef46241614a</b>
                 </div>
             </div>
             <div class="field-group">
@@ -125,14 +126,15 @@
                     <code>pr:comment:edited</code>,
                     <code>pr:comment:delete</code>,
                     <code>repo</code>,
-                    <code>repo:build_status</code>
+                    <code>repo:build_status</code>,
+                    <code>repo:refs_changed</code>
                 </div>
             </div>
             <div class="field-group">
                 <label for="secret">Secret:</label>
                 <input class="text long-field" type="text" name="secret" id="secret" required minlength="1">
                 <div class="description">
-                    The secret be used in the <a href="https://docs.sourcegraph.com/admin/external_service/bitbucket_server#webhooks">Bitbucket Server configuration</a> on your Sourcegraph instance.
+                    The secret from the uncoming Webhook configuration page in Sourcegraph.
                 </div>
             </div>
             <div class="buttons-container">


### PR DESCRIPTION
- The inline doc strings still mentioned the old deprecated URL format - so fixed that.
- I also split development and user instructions up, and fixed that they actually work in 2024 on an ARM based Mac.
- The docs for webhooks mentioned to add `repo:refs_changed` to the list, but that was not mentioned as one of the valid options, so added it to the list.
- Finally, added a missing handler for repo push events so they get properly dispatched, and added the payload shape to the readme for reference.

New settings page screenshot: 

![Screenshot 2024-06-07 at 18.31.57@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Xvbrpl1hwVbe4tb9QeLp/1e8c7b8d-e377-4246-90f9-c097c07f93c1.png)


Webhooks for push events work:

![Screenshot 2024-06-11 at 10 48 45@2x](https://github.com/sourcegraph/bitbucket-server-plugin/assets/19534377/78630cc7-3089-4a27-b4dc-a93e06bca50d)

Works on SRC-387.

Test plan:

Ran locally using `atlas-run` and verified that webhooks are properly fired now, and installed the new extension version to our bitbucket instance and verified it triggers correctly.