### PR TITLE
Fix CI scripts

### DIFF
--- a/.buildkite/ci-checkov.sh
+++ b/.buildkite/ci-checkov.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # Install and run the plugin for checkov
 # Use the full path to run pip3.10
-pip3 install checkov
+pip3 --break-system-packages install checkov
 
 # List of checks we do not want to run here
 # This is a living list and will see additions and mostly removals over time.

--- a/.buildkite/ci-checkov.sh
+++ b/.buildkite/ci-checkov.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # Install and run the plugin for checkov
 # Use the full path to run pip3.10
-pip3 --break-system-packages install checkov
+pip3 install --break-system-packages checkov
 
 # List of checks we do not want to run here
 # This is a living list and will see additions and mostly removals over time.

--- a/.buildkite/ci-checkov.sh
+++ b/.buildkite/ci-checkov.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 # Install and run the plugin for checkov
 # Use the full path to run pip3.10
-pip3 install --break-system-packages checkov
+pip3 install --break-system-packages --ignore-installed checkov
 
 # List of checks we do not want to run here
 # This is a living list and will see additions and mostly removals over time.


### PR DESCRIPTION
Fix the pipeline scripts, specifically running `checkov`, by telling `pip3 install` to ignore system-installed packages