### PR TITLE
chore(source): fix java version in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@ brew tap atlassian/tap
 brew install atlassian/tap/atlassian-plugin-sdk
 ```
 
-Don't forget to set you `JAVA_HOME` environment variable for Java 8. On MacOS you can see your Java installations with the following command:
+Don't forget to set your `JAVA_HOME` environment variable for Java 17. On MacOS you can see your Java installations with the following command:
 
 ```sh
 /usr/libexec/java_home -V


### PR DESCRIPTION
When I was setting up a local instance of BitBucket Server, I ran into an issue caused by at first being told to use Java 8, but then being told to use Java 17. So, changing both instruction instances to be Java 17 :) 

Also fixing a quick typo: 'you' -> 'your' in `JAVA_HOME` command.